### PR TITLE
Force UTF-8 encoding for all java compilation tasks

### DIFF
--- a/src/main/groovy/com/cloudogu/smp/GradleSmpPlugin.groovy
+++ b/src/main/groovy/com/cloudogu/smp/GradleSmpPlugin.groovy
@@ -8,6 +8,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
+import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 
 class GradleSmpPlugin implements Plugin<Project> {
@@ -26,12 +27,9 @@ class GradleSmpPlugin implements Plugin<Project> {
       }
     }
 
-    project.compileJava {
+    project.tasks.withType(JavaCompile) {
       options.release = 8
-    }
-
-    project.compileTestJava {
-      options.release = 8
+      options.encoding = 'UTF-8'
     }
 
     def packageJson = new PackageJson(project)


### PR DESCRIPTION
## Proposed changes

Forces UTF-8 encoding for all tasks of type JavaCompile

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch

