### PR TITLE
Add smp variant to published gradle module

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/com/cloudogu/smp/Dependencies.groovy
+++ b/src/main/groovy/com/cloudogu/smp/Dependencies.groovy
@@ -77,12 +77,13 @@ class Dependencies {
       .setVisible(false)
       .setDescription("Additional classpath for libraries which are provided from scm code.")
 
+    configurationContainer.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME).extendsFrom(coreDependency)
+
     Configuration pluginDependency = configurationContainer
       .create("plugin")
       .resolutionStrategy(noCacheResolutionStrategy)
       .setVisible(false)
       .setDescription("Plugin dependencies.")
-      .extendsFrom(coreDependency)
 
     pluginDependency.canBeConsumed = true
 
@@ -93,7 +94,6 @@ class Dependencies {
       .resolutionStrategy(noCacheResolutionStrategy)
       .setVisible(false)
       .setDescription("Optional plugin dependencies.")
-      .extendsFrom(coreDependency)
 
     configurationContainer.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME).extendsFrom(optionalPlugin)
 
@@ -106,7 +106,7 @@ class Dependencies {
       it.attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
       it.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, "smp"))
 
-      runtimeScmElements.extendsFrom(pluginDependency, optionalPlugin)
+      runtimeScmElements.extendsFrom(coreDependency, pluginDependency, optionalPlugin)
     }
   }
 

--- a/src/main/groovy/com/cloudogu/smp/PackagingTasks.groovy
+++ b/src/main/groovy/com/cloudogu/smp/PackagingTasks.groovy
@@ -6,6 +6,10 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.attributes.Bundling
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.tasks.bundling.War
@@ -16,9 +20,15 @@ class PackagingTasks {
     PublishArtifact artifact = registerSmpTasks(project, extension)
     registerPluginXml(project, packageJson, extension)
 
-
     Configuration smpArtifacts = project.configurations.create('smp')
-    smpArtifacts.canBeResolved = false
+      .setDescription('smp variant of plugin')
+      .attributes { it ->
+        it.attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
+        it.attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
+        it.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+        it.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, "smp"))
+      }
+    smpArtifacts.canBeResolved = true
     smpArtifacts.canBeConsumed = true
 
     project.afterEvaluate {

--- a/src/main/groovy/com/cloudogu/smp/PackagingTasks.groovy
+++ b/src/main/groovy/com/cloudogu/smp/PackagingTasks.groovy
@@ -28,7 +28,11 @@ class PackagingTasks {
         it.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
         it.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, "smp"))
       }
-    smpArtifacts.canBeResolved = true
+      .extendsFrom(
+        project.configurations.getByName("plugin"),
+        project.configurations.getByName("optionalPlugin")
+      )
+    smpArtifacts.canBeResolved = false
     smpArtifacts.canBeConsumed = true
 
     project.afterEvaluate {

--- a/src/main/groovy/com/cloudogu/smp/PublishingTasks.groovy
+++ b/src/main/groovy/com/cloudogu/smp/PublishingTasks.groovy
@@ -1,8 +1,10 @@
 package com.cloudogu.smp
 
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.component.AdhocComponentWithVariants
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.authentication.http.BasicAuthentication
 import org.gradle.api.tasks.javadoc.Javadoc
@@ -27,6 +29,15 @@ class PublishingTasks {
       failOnError false
     }
 
+    // we have to add our smp artifact as variant of the java component (jar)
+    // in order to resolve the smp from a deployed gradle module file
+    AdhocComponentWithVariants javaComponent = (AdhocComponentWithVariants) project.components.findByName("java")
+    // smp configuration is defined as part of packaging tasks
+    Configuration outgoing = project.configurations.getByName("smp")
+    javaComponent.addVariantsFromConfiguration(outgoing) {
+      // we don't need any customizing here
+    }
+
     project.publishing {
       publications {
         mavenJava(MavenPublication) {
@@ -35,7 +46,6 @@ class PublishingTasks {
           version = project.version
 
           from project.components.java
-          artifact smp
 
           pom {
             packaging = "smp"


### PR DESCRIPTION
## Proposed changes

Currently smp dependencies of plugins deployed with Gradle are not resolved as smp, only the jar is resolved.
The problem is with the deployed gradle module, which is missing the smp variant of the plugin.
This change will add the smp variant to gradle module.

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
