### PR TITLE
Skip parsing and appending moduleXml content if not available

### DIFF
--- a/src/main/groovy/com/cloudogu/smp/PackagingTasks.groovy
+++ b/src/main/groovy/com/cloudogu/smp/PackagingTasks.groovy
@@ -107,7 +107,10 @@ class PackagingTasks {
 
     project.tasks.register("plugin-xml", PluginXmlTask) {
       it.extension = extension
-      it.moduleXml = new File(project.buildDir, "classes/java/main/META-INF/scm/module.xml")
+      File moduleXml = new File(project.buildDir, "classes/java/main/META-INF/scm/module.xml")
+      if (moduleXml.exists()) {
+        it.moduleXml = moduleXml
+      }
       it.pluginXml = new File(project.buildDir, "smp/META-INF/scm/plugin.xml")
       if (packageJson.exists()) {
         it.packageJson = packageJson

--- a/src/main/groovy/com/cloudogu/smp/PluginXmlTask.groovy
+++ b/src/main/groovy/com/cloudogu/smp/PluginXmlTask.groovy
@@ -65,6 +65,7 @@ class PluginXmlTask extends DefaultTask {
     this.pluginXml = pluginXml
   }
 
+  @Optional
   @InputFile
   @PathSensitive(PathSensitivity.RELATIVE)
   File getModuleXml() {
@@ -92,7 +93,6 @@ class PluginXmlTask extends DefaultTask {
     }
 
     def xml = new NodeBuilder()
-    def module = new XmlParser().parse(moduleXml)
 
     def output = xml.plugin {
       'scm-version'('2')
@@ -144,8 +144,11 @@ class PluginXmlTask extends DefaultTask {
       }
     }
 
-    module.each { node ->
-      output.append node
+    if (moduleXml) {
+      def module = new XmlParser().parse(moduleXml)
+      module.each { node ->
+        output.append node
+      }
     }
 
     def document = DOMBuilder.parse(new StringReader(XmlUtil.serialize(output)))


### PR DESCRIPTION
## Proposed changes

Skip parsing and appending moduleXml content if not available. This applies especially to plugins without a backend part and was noticed during plugin changeover to gradle-smp.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
