### PR TITLE
Fix rewrite of server configuration on snapshots

### DIFF
--- a/src/main/groovy/com/cloudogu/smp/Dependencies.groovy
+++ b/src/main/groovy/com/cloudogu/smp/Dependencies.groovy
@@ -71,6 +71,15 @@ class Dependencies {
       cacheChangingModulesFor 0, "seconds"
     }
 
+    Configuration scmServer = configurationContainer
+      .create("scmServer")
+      .resolutionStrategy(noCacheResolutionStrategy)
+      .setVisible(false)
+      .setDescription("Dependencies required to start the development environment")
+
+    scmServer.canBeResolved = true
+    scmServer.canBeConsumed = false
+
     Configuration coreDependency = configurationContainer
       .create("scmCoreDependency")
       .resolutionStrategy(noCacheResolutionStrategy)
@@ -130,6 +139,8 @@ class Dependencies {
         testImplementation "sonia.scm:scm-test:${extension.scmVersion}"
         annotationProcessor "sonia.scm:scm-annotation-processor:${extension.scmVersion}"
       }
+
+      scmServer "sonia.scm:scm-webapp:${extension.scmVersion}@war"
 
       // is provided in scm-core
       scmCoreDependency "javax.ws.rs:javax.ws.rs-api:2.1.1"

--- a/src/main/groovy/com/cloudogu/smp/RunTasks.groovy
+++ b/src/main/groovy/com/cloudogu/smp/RunTasks.groovy
@@ -44,6 +44,7 @@ class RunTasks {
     project.tasks.register("write-server-config", WriteServerConfigTask) {
       description = "Writes the configuration for run task"
       it.extension = extension
+      it.configuration = project.configurations.getByName("scmServer")
       it.outputFile = extension.getServerConfigurationFile(project)
     }
 


### PR DESCRIPTION
## Proposed changes

This change fixes a missing rewrite of the server configuration in the following scenario: The plugin depends on a snapshot version of scm-manager, which is downloaded on first run, then another core snapshot is deployed to local maven repository and the plugin is started again without a change.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
