### PR TITLE
Fix wrong checksum on release

### DIFF
--- a/src/main/groovy/com/cloudogu/smp/PackagingTasks.groovy
+++ b/src/main/groovy/com/cloudogu/smp/PackagingTasks.groovy
@@ -95,6 +95,7 @@ class PackagingTasks {
       it.pluginVersion = project.version
 
       dependsOn("smp")
+      mustRunAfter("smp")
     }
 
     new LazyPublishArtifact(smp)

--- a/src/main/groovy/com/cloudogu/smp/PublishingTasks.groovy
+++ b/src/main/groovy/com/cloudogu/smp/PublishingTasks.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.component.AdhocComponentWithVariants
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.gradle.authentication.http.BasicAuthentication
 import org.gradle.api.tasks.javadoc.Javadoc
 
@@ -28,6 +29,13 @@ class PublishingTasks {
     project.tasks.withType(Javadoc) {
       failOnError false
     }
+
+    // ensure release-yaml is generate before artifact is published
+    // to be sure that the checksum is correct
+    project.tasks.withType(AbstractPublishToMaven) { 
+      it.dependsOn "release-yaml"
+    }
+
 
     // we have to add our smp artifact as variant of the java component (jar)
     // in order to resolve the smp from a deployed gradle module file

--- a/src/main/groovy/com/cloudogu/smp/UiTasks.groovy
+++ b/src/main/groovy/com/cloudogu/smp/UiTasks.groovy
@@ -128,7 +128,7 @@ class UiTasks {
       description = "Run ui tests"
     }
 
-    project.tasks.getByName("check").configure {
+    project.tasks.getByName("test").configure {
       dependsOn("ui-test")
     }
   }

--- a/src/test/groovy/com/cloudogu/smp/UiTasksTest.groovy
+++ b/src/test/groovy/com/cloudogu/smp/UiTasksTest.groovy
@@ -71,7 +71,7 @@ class UiTasksTest {
 
   @Test
   void shouldRegisterUiTestTask() {
-    project.tasks.register('check')
+    project.tasks.register('test')
     new File(directory, 'package.json') << '''
     {
       "scripts": {


### PR DESCRIPTION
## Proposed changes

Ensure that the release.yaml is created before a release is published to a maven repository. That should fix the wrong checksum problem on release builds.
The ui-tests are now running as part of test instead of check.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
