### PR TITLE
Stop plugins on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Stop plugin run on Windows ([#11](https://github.com/scm-manager/gradle-smp-plugin/pull/11))
+
 ## 0.10.1 - 2021-11-29
 ### Fixed
 - Broken publishing

--- a/src/main/groovy/com/cloudogu/smp/RunTask.groovy
+++ b/src/main/groovy/com/cloudogu/smp/RunTask.groovy
@@ -1,5 +1,8 @@
 package com.cloudogu.smp
 
+import com.google.common.base.CharMatcher
+import com.google.common.base.Splitter
+import com.moowork.gradle.node.task.NodeTask
 import com.moowork.gradle.node.yarn.YarnTask
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
@@ -37,7 +40,7 @@ class RunTask extends DefaultTask {
 
   @TaskAction
   void exec() {
-    List<Closure<Void>> actions = new ArrayList<>();
+    List<Closure<Void>> actions = new ArrayList<>()
     actions.add(createBackend())
     if (packageJson.hasScript("watch")) {
       actions.add(createFrontend())
@@ -78,6 +81,7 @@ class RunTask extends DefaultTask {
         }
         execSpecActions.each { a -> a.execute(jes) }
       }
+      return null
     }
   }
 
@@ -91,13 +95,32 @@ class RunTask extends DefaultTask {
     if (!home.exists()) {
       home.mkdirs()
     }
-    def frontend = project.tasks.create("boot-frontend", YarnTask) {
-      args = ['run', 'watch']
-      environment = [
-        "BUNDLE_OUTPUT": home.absolutePath,
-        "NODE_ENV"     : "development"
-      ]
+
+    def env = [
+      "BUNDLE_OUTPUT": home.absolutePath,
+      "NODE_ENV"     : "development"
+    ]
+
+    def frontend
+    def script = packageJson.getScript("watch").orElseThrow(
+      () -> new IllegalStateException("could not find watch script in package.json")
+    )
+    // we call the plugin scripts directly, to avoid stop problems with yarn on windows
+    if (script.startsWith("plugin-scripts")) {
+      def args = Splitter.on(CharMatcher.whitespace()).omitEmptyStrings().trimResults().splitToList(script)
+      frontend = project.tasks.create("boot-frontend", NodeTask) {
+        it.script = new File(project.projectDir, "node_modules/@scm-manager/plugin-scripts/bin/plugin-scripts.js")
+        it.args = args.subList(1, args.size())
+        it.environment = env
+      }
+    } else {
+      // if we not use plugin-scripts for our watch script we fallback to start it with yarn
+      frontend = project.tasks.create("boot-frontend", YarnTask) {
+        it.args = ['run', 'watch']
+        it.environment = env
+      }
     }
+
     return {
       frontend.exec()
     }

--- a/src/main/groovy/com/cloudogu/smp/RunTask.groovy
+++ b/src/main/groovy/com/cloudogu/smp/RunTask.groovy
@@ -102,9 +102,9 @@ class RunTask extends DefaultTask {
     ]
 
     def frontend
-    def script = packageJson.getScript("watch").orElseThrow(
-      () -> new IllegalStateException("could not find watch script in package.json")
-    )
+    def script = packageJson.getScript("watch").orElseThrow({ ->
+      new IllegalStateException("could not find watch script in package.json")
+    })
     // we call the plugin scripts directly, to avoid stop problems with yarn on windows
     if (script.startsWith("plugin-scripts")) {
       def args = Splitter.on(CharMatcher.whitespace()).omitEmptyStrings().trimResults().splitToList(script)


### PR DESCRIPTION
## Proposed changes

Trying to stop a plugin on Windows lead to a dangling node process which prevented stopping the run completely. We now call the plugin-scripts directly to avoid such problems with yarn on Windows. If the watch script in package.json does not use plugin-scripts we start it with yarn as before as a fallback, knowing that stopping the plugin might not work on Windows.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
