### PR TITLE
Set the line ending used for license files to LF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Set line ending used for license files to LF ([#12](https://github.com/scm-manager/gradle-smp-plugin/pull/12))
+
 ## 0.10.2 - 2021-12-21
 ### Fixed
 - Stop plugin run on Windows ([#11](https://github.com/scm-manager/gradle-smp-plugin/pull/11))

--- a/src/main/groovy/com/cloudogu/smp/LicenseTasks.groovy
+++ b/src/main/groovy/com/cloudogu/smp/LicenseTasks.groovy
@@ -27,6 +27,7 @@ class LicenseTasks {
       header licenseFile
       newLine = true
       ignoreNewLine = true
+      lineEnding = "\n"
 
       exclude "**/*.mustache"
       exclude "**/*.json"


### PR DESCRIPTION
## Proposed changes

Set line ending explicitly to LF because on Windows using the system line ending does not get along well with our git settings.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
