### PR TITLE
Keep plugins on rerun plugin

### DIFF
--- a/src/main/groovy/com/cloudogu/smp/CopyPluginsTask.groovy
+++ b/src/main/groovy/com/cloudogu/smp/CopyPluginsTask.groovy
@@ -3,7 +3,6 @@ package com.cloudogu.smp
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -33,7 +32,7 @@ class CopyPluginsTask extends DefaultTask {
       .findAll {
         it.extension == "smp"
       }
-      .collectEntries { [(it.file.name): withoutVersion(it)] } as Map<String, String>
+      .collectEntries { [(it.file.name): it.name + '.smp'] } as Map<String, String>
   }
 
   @TaskAction
@@ -43,7 +42,7 @@ class CopyPluginsTask extends DefaultTask {
       throw new GradleException("failed to create plugin directory: " + directory);
     }
     def withoutVersion = lookup.get()
-    project.sync {
+    project.copy {
       into(directory)
       from(configuration) {
         include('*.smp')
@@ -53,9 +52,4 @@ class CopyPluginsTask extends DefaultTask {
       }
     }
   }
-
-  private static String withoutVersion(ResolvedArtifact artifact) {
-    artifact.name + '.smp'
-  }
-
 }


### PR DESCRIPTION
## Proposed changes

Use `copy` instead of `sync` for the CopyPluginTask. Sync deletes everything before copying, but we want to keep the already installed plugins.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [ ] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
