### PR TITLE
Use Java 11 as compile version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Use Java 11 as compile version ([#13](https://github.com/scm-manager/gradle-smp-plugin/pull/13))
+
 ## 0.10.3 - 2021-12-22
 ### Fixed
 - Set line ending used for license files to LF ([#12](https://github.com/scm-manager/gradle-smp-plugin/pull/12))

--- a/build.gradle
+++ b/build.gradle
@@ -54,13 +54,13 @@ dependencies {
 }
 
 project.tasks.withType(GroovyCompile) {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_11
+  targetCompatibility = JavaVersion.VERSION_11
 }
 
 project.tasks.withType(JavaCompile) {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_11
+  targetCompatibility = JavaVersion.VERSION_11
 }
 
 test {

--- a/src/main/groovy/com/cloudogu/smp/GradleSmpPlugin.groovy
+++ b/src/main/groovy/com/cloudogu/smp/GradleSmpPlugin.groovy
@@ -29,7 +29,7 @@ class GradleSmpPlugin implements Plugin<Project> {
     }
 
     project.tasks.withType(JavaCompile) {
-      options.release = 8
+      options.release = 11
       options.encoding = 'UTF-8'
     }
 


### PR DESCRIPTION
## Proposed changes

This sets Java 11 for compilation, when the core version is set to 2.35.0 or higher, assuming that the core is released with the release of this pr with version 2.35.0. During the release it is essential to sync the release versions.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
