### PR TITLE
Use Java 11 as compile version

### DIFF
--- a/src/main/groovy/com/cloudogu/smp/Dependencies.groovy
+++ b/src/main/groovy/com/cloudogu/smp/Dependencies.groovy
@@ -122,6 +122,8 @@ class Dependencies {
   }
 
   private static void configureDependencies(Project project, SmpExtension extension) {
+    String scmVersion = extension.scmVersion.get()
+
     // gradle has xerces on it classpath, which breaks our annotation processor
     // so we force jdk build in for now
     // @see https://stackoverflow.com/questions/53299280/java-and-xerces-cant-find-property-xmlconstants-access-external-dtd
@@ -136,10 +138,10 @@ class Dependencies {
         scmCoreDependency project.project(':scm-test')
         annotationProcessor project.project(':scm-annotation-processor')
       } else {
-        scmCoreDependency enforcedPlatform("sonia.scm:scm:${extension.scmVersion}")
-        scmCoreDependency "sonia.scm:scm-core:${extension.scmVersion}"
-        testImplementation "sonia.scm:scm-test:${extension.scmVersion}"
-        annotationProcessor "sonia.scm:scm-annotation-processor:${extension.scmVersion}"
+        scmCoreDependency enforcedPlatform("sonia.scm:scm:${scmVersion}")
+        scmCoreDependency "sonia.scm:scm-core:${scmVersion}"
+        testImplementation "sonia.scm:scm-test:${scmVersion}"
+        annotationProcessor "sonia.scm:scm-annotation-processor:${scmVersion}"
       }
 
       scmServer "sonia.scm:scm-webapp:${extension.scmVersion}@war"

--- a/src/main/groovy/com/cloudogu/smp/GradleSmpPlugin.groovy
+++ b/src/main/groovy/com/cloudogu/smp/GradleSmpPlugin.groovy
@@ -22,6 +22,9 @@ class GradleSmpPlugin implements Plugin<Project> {
     project.plugins.apply(MavenPublishPlugin)
     project.plugins.apply(com.cloudogu.changelog.GradlePlugin)
 
+    def extension = project.extensions.create("scmPlugin", SmpExtension, project)
+    def jvmVersion = extension.scmVersion.map(v -> v.equals("2.29.0") ? 8 : 11)
+
     project.java {
       toolchain {
         languageVersion = JavaLanguageVersion.of(11)
@@ -29,12 +32,11 @@ class GradleSmpPlugin implements Plugin<Project> {
     }
 
     project.tasks.withType(JavaCompile) {
-      options.release = 8
+      options.release = jvmVersion
       options.encoding = 'UTF-8'
     }
 
     def packageJson = new PackageJson(project)
-    def extension = project.extensions.create("scmPlugin", SmpExtension)
 
     AnalysisTasks.configure(project, extension, packageJson)
     DoctorTasks.configure(project, extension, packageJson)

--- a/src/main/groovy/com/cloudogu/smp/GradleSmpPlugin.groovy
+++ b/src/main/groovy/com/cloudogu/smp/GradleSmpPlugin.groovy
@@ -13,6 +13,20 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion
 
 class GradleSmpPlugin implements Plugin<Project> {
 
+  int determineJavaVersion(String version) {
+    String[] versionParts = version.split("\\.")
+    if (versionParts.length < 2) {
+      return 8
+    }
+    def majorVersion = versionParts[0] as int
+    def minorVersion = versionParts[1] as int
+    if (majorVersion == 2 && minorVersion < 35) {
+      return 8
+    } else {
+      return 11
+    }
+  }
+
   void apply(Project project) {
     if (!project.version?.trim() || "unspecified".equals(project.version) ) {
       throw new GradleException("version is missing in gradle.properties")
@@ -23,7 +37,7 @@ class GradleSmpPlugin implements Plugin<Project> {
     project.plugins.apply(com.cloudogu.changelog.GradlePlugin)
 
     def extension = project.extensions.create("scmPlugin", SmpExtension, project)
-    def jvmVersion = extension.scmVersion.map(v -> v.equals("2.29.0") ? 8 : 11)
+    def jvmVersion = extension.scmVersion.map(v -> determineJavaVersion(v))
 
     project.java {
       toolchain {

--- a/src/main/groovy/com/cloudogu/smp/PluginXmlTask.groovy
+++ b/src/main/groovy/com/cloudogu/smp/PluginXmlTask.groovy
@@ -99,7 +99,7 @@ class PluginXmlTask extends DefaultTask {
         }
       }
       conditions {
-        'min-version'(ext.scmVersion)
+        'min-version'(ext.scmVersion.get())
         if (ext.pluginConditions.os != null) {
           os(ext.pluginConditions.os)
         }

--- a/src/main/groovy/com/cloudogu/smp/ReleaseYamlTask.groovy
+++ b/src/main/groovy/com/cloudogu/smp/ReleaseYamlTask.groovy
@@ -94,7 +94,7 @@ class ReleaseYamlTask extends DefaultTask {
         optionalDependencies optionalPluginDeps
       }
       conditions {
-        minVersion extension.scmVersion
+        minVersion extension.getScmVersion().get()
         if (extension.pluginConditions.os != null) {
           os extension.pluginConditions.os
         }

--- a/src/main/groovy/com/cloudogu/smp/SmpExtension.groovy
+++ b/src/main/groovy/com/cloudogu/smp/SmpExtension.groovy
@@ -1,14 +1,15 @@
 package com.cloudogu.smp
 
 import org.gradle.api.Project
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 
-class SmpExtension implements Serializable {
+abstract class SmpExtension implements Serializable {
 
   @Input
-  String scmVersion = "2.0.0"
+  final Property<String> scmVersion
 
   @Input
   String group = "sonia.scm.plugins"
@@ -51,6 +52,10 @@ class SmpExtension implements Serializable {
 
   @Nested
   ScmServerConfiguration serverConfiguration = new ScmServerConfiguration()
+
+  SmpExtension(Project project) {
+    this.scmVersion = project.objects.property(String).convention("2.0.0")
+  }
 
   def conditions(Closure<Void> closure) {
     closure.delegate = pluginConditions

--- a/src/main/groovy/com/cloudogu/smp/doctor/rules/MinScmVersionRule.groovy
+++ b/src/main/groovy/com/cloudogu/smp/doctor/rules/MinScmVersionRule.groovy
@@ -50,7 +50,7 @@ class MinScmVersionRule implements Rule {
     Collections.sort(plugins)
 
     Plugin pluginWithHighestMinVersion = plugins.last()
-    VersionNumber currentVersion = VersionNumber.parse(context.extension.scmVersion)
+    VersionNumber currentVersion = VersionNumber.parse(context.extension.getScmVersion().get())
     if (currentVersion.compareTo(pluginWithHighestMinVersion.version) < 0) {
       String message = String.format(
         ERROR_MIN_VERSION, currentVersion, pluginWithHighestMinVersion.name, pluginWithHighestMinVersion.version


### PR DESCRIPTION
## Proposed changes

This sets Java 11 for compilation, when the core is used in version 2.35.0 or higher, assuming that the core is released with the release of this pr with version 2.35.0. During the release it is essential to sync the release versions. If this is released with another core version (with pull request scm-manager/scm-manager#2033), the new version has to be set in the `GradleSmpPlugin` in line 23.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
