### PR TITLE
Handle plugin config field "childFirstClassloader"

### DIFF
--- a/gradle/changelog/childFirstClassloader.yaml
+++ b/gradle/changelog/childFirstClassloader.yaml
@@ -1,0 +1,2 @@
+- type: added
+  description: Add property to use ChildFirstClassloader in plugins ([#17](https://github.com/scm-manager/gradle-smp-plugin/pull/17))

--- a/src/main/groovy/com/cloudogu/smp/PluginXmlTask.groovy
+++ b/src/main/groovy/com/cloudogu/smp/PluginXmlTask.groovy
@@ -77,10 +77,12 @@ class PluginXmlTask extends DefaultTask {
 
     def output = xml.plugin {
       'scm-version'('2')
+      if (ext.childFirstClassloader) {
+        "child-first-classloader"(ext.childFirstClassloader)
+      }
       information {
         createNode('name', pluginName.get())
         version(pluginVersion)
-
         if (ext.displayName != null) {
           displayName(ext.displayName)
         }
@@ -97,6 +99,7 @@ class PluginXmlTask extends DefaultTask {
         if (ext.avatarUrl != null) {
           avatarUrl(ext.avatarUrl)
         }
+
       }
       conditions {
         'min-version'(ext.scmVersion.get())

--- a/src/main/groovy/com/cloudogu/smp/SmpExtension.groovy
+++ b/src/main/groovy/com/cloudogu/smp/SmpExtension.groovy
@@ -42,6 +42,9 @@ abstract class SmpExtension implements Serializable {
   boolean core = false
 
   @Input
+  boolean childFirstClassloader = false
+
+  @Input
   Map<String,String> sonarProperties = [:]
 
   @Nested

--- a/src/test/groovy/com/cloudogu/smp/PluginXmlTaskTest.groovy
+++ b/src/test/groovy/com/cloudogu/smp/PluginXmlTaskTest.groovy
@@ -1,15 +1,14 @@
 package com.cloudogu.smp
 
-import groovy.mock.interceptor.MockFor
+
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
-import org.gradle.api.provider.Property
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
 import java.nio.file.Path
 
-import static org.assertj.core.api.Assertions.*
+import static org.assertj.core.api.Assertions.assertThat
 
 class PluginXmlTaskTest {
 
@@ -36,6 +35,7 @@ class PluginXmlTaskTest {
     extension.category = "Sample"
     extension.author = "Cloudogu GmbH"
     extension.avatarUrl = '/images/avatar.png'
+    extension.childFirstClassloader = true
     extension.conditions {
       os = "Linux"
       arch = "arm"
@@ -70,6 +70,7 @@ class PluginXmlTaskTest {
     assertThat(plugin.information.category).isEqualTo("Sample")
     assertThat(plugin.information.author).isEqualTo("Cloudogu GmbH")
     assertThat(plugin.information.avatarUrl).isEqualTo('/images/avatar.png')
+    assertThat(plugin["child-first-classloader"]).isEqualTo(true)
 
     assertThat(plugin.resources.script).isEqualTo("assets/scm-sample-plugin.bundle.js")
 


### PR DESCRIPTION
Handle property "childFirstClassloader" for plugin.xml to enable the usage of the ChildFirstClassloader instead of the DefaultPluginClassloader for plugins.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Please ensure the "what" and "why" are explained properly in this description as it will be used as the commit description on squashing your pull request commits. 

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
