### PR TITLE
Fix version for jackson

### DIFF
--- a/src/main/groovy/com/cloudogu/smp/PackagingTasks.groovy
+++ b/src/main/groovy/com/cloudogu/smp/PackagingTasks.groovy
@@ -137,6 +137,7 @@ class PackagingTasks {
         dependencies.add(project.getDependencies().create("io.swagger.core.v3:swagger-jaxrs2:2.1.6"))
         dependencies.add(project.getDependencies().create("javax.ws.rs:javax.ws.rs-api:2.1"))
         dependencies.add(project.getDependencies().create("javax.servlet:javax.servlet-api:3.1.0"))
+        dependencies.add(project.getDependencies().create("com.fasterxml.jackson.core:jackson-core:2.13.4"))
       }
     })
 

--- a/src/main/groovy/com/cloudogu/smp/PackagingTasks.groovy
+++ b/src/main/groovy/com/cloudogu/smp/PackagingTasks.groovy
@@ -127,6 +127,17 @@ class PackagingTasks {
     }
   }
 
+  private static boolean needsJackson(String version) {
+    String[] versionParts = version.split("[.-]")
+    if (versionParts.length < 2) {
+      return false
+    }
+    def majorVersion = versionParts[0] as int
+    def minorVersion = versionParts[1] as int
+    def patchVersion = versionParts[2] as int
+    return majorVersion == 2 && (minorVersion > 39 || minorVersion == 39 && patchVersion > 1)
+  }
+
   private static void registerOpenApiSpecGenerator(Project project, SmpExtension extension) {
     final Configuration config = project.configurations.create("swaggerDeps")
       .setVisible(false)
@@ -137,7 +148,9 @@ class PackagingTasks {
         dependencies.add(project.getDependencies().create("io.swagger.core.v3:swagger-jaxrs2:2.1.6"))
         dependencies.add(project.getDependencies().create("javax.ws.rs:javax.ws.rs-api:2.1"))
         dependencies.add(project.getDependencies().create("javax.servlet:javax.servlet-api:3.1.0"))
-        dependencies.add(project.getDependencies().create("com.fasterxml.jackson.core:jackson-core:2.13.4"))
+        if (needsJackson(extension.scmVersion.get())) {
+          dependencies.add(project.getDependencies().create("com.fasterxml.jackson.core:jackson-core:2.13.4"))
+        }
       }
     })
 


### PR DESCRIPTION
## Proposed changes

This adds jackson core as a new dependency to fix errors due to different versions of jackson between core and smp plugin.
The dependency is only added, if the core version is 2.39.2 or later.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
